### PR TITLE
Add MCP client adapter and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ python -m eval_agent.cli run configs/sentiment_keyword.json
 
 # Trained scikit-learn pipeline (requires the artifact from step 2)
 python -m eval_agent.cli run configs/sentiment_sklearn.json
+
+# Remote MCP-backed model (set the endpoint and export MCP_API_KEY before running)
+export MCP_API_KEY=your_api_key
+python -m eval_agent.cli run configs/sentiment_mcp.json
 ```
 
 Results are written to `runs/` as JSON (ignored by git). The CLI will also print a summary and, by
@@ -171,6 +175,10 @@ python -m eval_agent.cli run configs/sentiment_keyword.json
 
 # Trained scikit-learn pipeline (requires the artifact from step 2)
 python -m eval_agent.cli run configs/sentiment_sklearn.json
+
+# Remote MCP-backed model (set the endpoint and export MCP_API_KEY before running)
+export MCP_API_KEY=your_api_key
+python -m eval_agent.cli run configs/sentiment_mcp.json
 ```
 
 Results are written to `runs/` as JSON (ignored by git). The CLI will also print a summary and, by

--- a/configs/sentiment_mcp.json
+++ b/configs/sentiment_mcp.json
@@ -1,0 +1,32 @@
+{
+  "name": "sentiment-mcp-remote",
+  "task": "text-classification",
+  "model": {
+    "type": "mcp",
+    "parameters": {
+      "endpoint": "https://example.com/mcp",  
+      "model_id": "sentiment-classifier",
+      "instruction": "Classify the review as positive, negative, or neutral.",
+      "auth": {
+        "type": "bearer",
+        "token_env": "MCP_API_KEY"
+      }
+    }
+  },
+  "dataset": {
+    "type": "jsonl-classification",
+    "parameters": {
+      "path": "../data/sentiment_eval.jsonl"
+    }
+  },
+  "metrics": [
+    {"type": "accuracy", "name": "accuracy"},
+    {"type": "precision", "name": "precision_macro", "parameters": {"average": "macro"}},
+    {"type": "recall", "name": "recall_macro", "parameters": {"average": "macro"}},
+    {"type": "f1", "name": "f1_macro", "parameters": {"average": "macro"}}
+  ],
+  "output": {
+    "directory": "../runs",
+    "save_predictions": true
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "uvicorn>=0.23.0",
     "scikit-learn>=1.3.0",
     "joblib>=1.3.0",
+    "mcp>=1.14.0",
+    "httpx-sse>=0.4.1",
 ]
 
 [project.scripts]

--- a/src/eval_agent/models/__init__.py
+++ b/src/eval_agent/models/__init__.py
@@ -1,0 +1,3 @@
+"""Model adapter implementations."""
+
+from .mcp import MCPModelAdapter as MCPModelAdapter  # noqa: F401

--- a/src/eval_agent/models/mcp.py
+++ b/src/eval_agent/models/mcp.py
@@ -1,0 +1,301 @@
+"""Adapter that proxies model requests over the Model Context Protocol."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Any, AsyncContextManager, Callable, Iterable, Optional
+
+from mcp import McpError
+import mcp.types as mcp_types
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+
+from eval_agent.models.base import ModelAdapter
+from eval_agent.registry import MODEL_REGISTRY
+from eval_agent.types import Example, ModelResponse
+
+logger = logging.getLogger(__name__)
+
+SessionFactory = Callable[[], AsyncContextManager[ClientSession]]
+
+
+def _to_json_serialisable(value: Any) -> Any:
+    """Ensure complex values are converted into JSON-friendly structures."""
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_to_json_serialisable(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _to_json_serialisable(item) for key, item in value.items()}
+    return json.loads(json.dumps(value, default=str))
+
+
+@MODEL_REGISTRY.register("mcp")
+class MCPModelAdapter(ModelAdapter):
+    """Model adapter that connects to an MCP server via the SSE transport."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        model_id: str,
+        auth: str | dict[str, Any] | None = None,
+        instruction: str | None = None,
+        headers: dict[str, str] | None = None,
+        transport: str = "sse",
+        http_timeout: float = 10.0,
+        sse_read_timeout: float = 300.0,
+        request_timeout: float | None = None,
+        session_factory: SessionFactory | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name)
+        if not endpoint:
+            raise ValueError("'endpoint' must be provided for the MCP adapter")
+        if not model_id:
+            raise ValueError("'model_id' must be provided for the MCP adapter")
+        if transport.lower() != "sse":
+            raise ValueError("Only the 'sse' transport is currently supported")
+
+        self.endpoint = endpoint
+        self.model_id = model_id
+        self.instruction = instruction
+        self.http_timeout = float(http_timeout)
+        self.sse_read_timeout = float(sse_read_timeout)
+        self.request_timeout = float(request_timeout) if request_timeout is not None else None
+        self._custom_session_factory = session_factory
+        self._server_info: dict[str, Any] | None = None
+        self._ready = False
+
+        self._headers = self._build_headers(auth, headers)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def warmup(self, examples: Iterable[Example] | None = None) -> None:
+        try:
+            self._run(self._warmup_async())
+        except RuntimeError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guardrail
+            raise RuntimeError("Unexpected failure during MCP warmup") from exc
+
+    def predict(self, example: Example) -> ModelResponse:
+        if not self._ready:
+            self._ensure_ready()
+
+        try:
+            return self._run(self._predict_async(example))
+        except RuntimeError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guardrail
+            raise RuntimeError(f"Unexpected MCP failure for example {example.uid}") from exc
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _run(self, coroutine: Any) -> Any:
+        return asyncio.run(coroutine)
+
+    def _ensure_ready(self) -> None:
+        try:
+            self._run(self._warmup_async())
+        except RuntimeError:
+            raise
+
+    async def _warmup_async(self) -> None:
+        async with self._session() as session:
+            try:
+                tools_result = await session.list_tools()
+            except McpError as exc:  # pragma: no cover - network/transport errors
+                raise RuntimeError(f"Failed to list tools from MCP server: {exc}") from exc
+
+            available = {tool.name for tool in tools_result.tools}
+            if self.model_id not in available:
+                raise RuntimeError(
+                    f"MCP server at {self.endpoint} does not expose tool '{self.model_id}'."
+                )
+
+        self._ready = True
+
+    async def _predict_async(self, example: Example) -> ModelResponse:
+        arguments = self._format_arguments(example)
+
+        async with self._session() as session:
+            try:
+                result = await session.call_tool(self.model_id, arguments)
+            except McpError as exc:
+                message = f"MCP tool call failed for example {example.uid}: {exc}"
+                logger.error(message)
+                raise RuntimeError(message) from exc
+
+        if result.isError:
+            message = self._format_error_message(result)
+            logger.error(message)
+            raise RuntimeError(message)
+
+        output, metadata = self._parse_result(result)
+        metadata.setdefault("example_uid", example.uid)
+        return ModelResponse(uid=example.uid, output=output, metadata=metadata)
+
+    def _format_arguments(self, example: Example) -> dict[str, Any]:
+        input_text = self._render_example_text(example)
+        message = mcp_types.SamplingMessage(
+            role="user",
+            content=mcp_types.TextContent(type="text", text=input_text),
+        )
+
+        metadata: dict[str, Any] = {"uid": example.uid}
+        if example.metadata:
+            metadata["example"] = _to_json_serialisable(example.metadata)
+
+        payload: dict[str, Any] = {
+            "model": self.model_id,
+            "messages": [message.model_dump(mode="json", by_alias=True)],
+            "input": _to_json_serialisable(example.inputs),
+            "metadata": metadata,
+        }
+
+        return payload
+
+    def _render_example_text(self, example: Example) -> str:
+        raw_input = example.inputs.get("text")
+        if isinstance(raw_input, str):
+            text = raw_input
+        else:
+            text = json.dumps(_to_json_serialisable(example.inputs), ensure_ascii=False)
+
+        if self.instruction:
+            return f"{self.instruction.strip()}\n\n{text}"
+        return text
+
+    def _parse_result(self, result: mcp_types.CallToolResult) -> tuple[Any, dict[str, Any]]:
+        text_blocks = [
+            block.text
+            for block in result.content
+            if isinstance(block, mcp_types.TextContent)
+        ]
+        output: Any
+        if text_blocks:
+            output = "\n".join(text_blocks)
+        elif result.structuredContent is not None:
+            output = result.structuredContent
+        else:
+            output = ""
+
+        metadata: dict[str, Any] = {
+            "tool": self.model_id,
+            "content": [
+                block.model_dump(mode="json", by_alias=True)
+                for block in result.content
+            ],
+        }
+        if result.structuredContent is not None:
+            metadata["structured"] = result.structuredContent
+        if self._server_info is not None:
+            metadata.setdefault("server_info", self._server_info)
+
+        return output, metadata
+
+    def _format_error_message(self, result: mcp_types.CallToolResult) -> str:
+        fragments = [
+            block.text
+            for block in result.content
+            if isinstance(block, mcp_types.TextContent)
+        ]
+        detail = "\n".join(fragments) if fragments else "(no error message provided)"
+        if result.structuredContent:
+            detail = f"{detail}\nStructured payload: {result.structuredContent}"
+        return f"MCP tool '{self.model_id}' returned an error response: {detail}"
+
+    def _build_headers(
+        self,
+        auth: str | dict[str, Any] | None,
+        headers: dict[str, str] | None,
+    ) -> dict[str, str]:
+        resolved: dict[str, str] = {}
+        if headers:
+            resolved.update(headers)
+
+        if auth is None:
+            return resolved
+
+        if isinstance(auth, str):
+            resolved["Authorization"] = f"Bearer {auth}"
+            return resolved
+
+        scheme = str(auth.get("type") or auth.get("scheme") or auth.get("kind") or "bearer").lower()
+        if scheme == "bearer":
+            token = self._extract_secret(auth, primary="token")
+            resolved["Authorization"] = f"Bearer {token}"
+            return resolved
+        if scheme in {"header", "api_key"}:
+            name = auth.get("name")
+            if not name:
+                raise ValueError("Auth configuration for 'header' requires a 'name'.")
+            value = self._extract_secret(auth, primary="value", fallbacks=("token",))
+            resolved[str(name)] = value
+            return resolved
+
+        raise ValueError(f"Unsupported auth scheme '{scheme}' for MCP adapter")
+
+    def _extract_secret(
+        self,
+        source: dict[str, Any],
+        *,
+        primary: str,
+        fallbacks: tuple[str, ...] = (),
+    ) -> str:
+        keys = (primary, *fallbacks)
+        for key in keys:
+            if key in source:
+                return self._coerce_secret(source[key])
+            env_key = f"{key}_env"
+            if env_key in source:
+                return self._read_env_var(str(source[env_key]))
+        if "env" in source:
+            return self._read_env_var(str(source["env"]))
+        raise ValueError(f"No value provided for '{primary}' in auth configuration")
+
+    def _coerce_secret(self, value: Any) -> str:
+        if isinstance(value, dict) and "env" in value:
+            return self._read_env_var(str(value["env"]))
+        return str(value)
+
+    def _read_env_var(self, name: str) -> str:
+        try:
+            return os.environ[name]
+        except KeyError as exc:
+            raise RuntimeError(f"Environment variable '{name}' is required for MCP auth") from exc
+
+    @asynccontextmanager
+    async def _session(self) -> AsyncIterator[ClientSession]:
+        factory = self._custom_session_factory or self._default_session_factory
+        async with factory() as session:
+            init_result = await session.initialize()
+            self._server_info = init_result.serverInfo.model_dump(mode="json", by_alias=True)
+            yield session
+
+    def _default_session_factory(self) -> AsyncIterator[ClientSession]:
+        return self._sse_session()
+
+    @asynccontextmanager
+    async def _sse_session(self) -> AsyncIterator[ClientSession]:
+        headers = self._headers or None
+        timeout_delta: Optional[timedelta]
+        timeout_delta = timedelta(seconds=self.request_timeout) if self.request_timeout else None
+
+        async with sse_client(
+            self.endpoint,
+            headers=headers,
+            timeout=self.http_timeout,
+            sse_read_timeout=self.sse_read_timeout,
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream, read_timeout_seconds=timeout_delta) as session:
+                yield session

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,0 +1,181 @@
+"""Tests for the MCP model adapter."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from mcp import McpError
+import mcp.types as mcp_types
+from mcp.client.session import SUPPORTED_PROTOCOL_VERSIONS
+
+from eval_agent.models.mcp import MCPModelAdapter
+from eval_agent.types import Example
+
+
+class FakeSessionFactory:
+    """Lightweight stand-in for an MCP client session."""
+
+    def __init__(
+        self,
+        *,
+        tool_name: str,
+        call_tool_result: mcp_types.CallToolResult,
+        side_effect: Exception | None = None,
+    ) -> None:
+        self.tool_name = tool_name
+        self.call_tool_result = call_tool_result
+        self.side_effect = side_effect
+        self.initialize_calls = 0
+        self.list_tools_calls = 0
+        self.call_tool_calls = 0
+        self.last_tool_name: str | None = None
+        self.last_arguments: dict[str, Any] | None = None
+
+    @asynccontextmanager
+    async def __call__(self):
+        factory = self
+
+        class _Session:
+            async def initialize(self) -> mcp_types.InitializeResult:
+                factory.initialize_calls += 1
+                return mcp_types.InitializeResult(
+                    protocolVersion=SUPPORTED_PROTOCOL_VERSIONS[0],
+                    capabilities=mcp_types.ServerCapabilities(),
+                    serverInfo=mcp_types.Implementation(name="stub-server", version="0.1.0"),
+                    instructions=None,
+                )
+
+            async def list_tools(self, cursor: str | None = None) -> mcp_types.ListToolsResult:
+                factory.list_tools_calls += 1
+                tool = mcp_types.Tool(name=factory.tool_name, inputSchema={})
+                return mcp_types.ListToolsResult(tools=[tool])
+
+            async def call_tool(self, name: str, arguments: dict[str, Any]) -> mcp_types.CallToolResult:
+                factory.call_tool_calls += 1
+                factory.last_tool_name = name
+                factory.last_arguments = arguments
+                if factory.side_effect is not None:
+                    raise factory.side_effect
+                return factory.call_tool_result
+
+        session = _Session()
+        yield session
+
+
+def _text_result(text: str, *, structured: dict[str, Any] | None = None, is_error: bool = False) -> mcp_types.CallToolResult:
+    content = [mcp_types.TextContent(type="text", text=text)]
+    return mcp_types.CallToolResult(content=content, structuredContent=structured, isError=is_error)
+
+
+def _example(text: str) -> Example:
+    return Example(uid="example-1", inputs={"text": text}, expected_output="positive")
+
+
+def test_mcp_adapter_warmup_and_predict() -> None:
+    factory = FakeSessionFactory(
+        tool_name="sentiment-classifier",
+        call_tool_result=_text_result("positive", structured={"score": 0.94}),
+    )
+    adapter = MCPModelAdapter(
+        endpoint="http://stub",  # not used by fake session
+        model_id="sentiment-classifier",
+        instruction="Classify the review as positive, negative, or neutral.",
+        session_factory=factory,
+    )
+
+    adapter.warmup(None)
+    assert factory.initialize_calls == 1
+    assert factory.list_tools_calls == 1
+
+    response = adapter.predict(_example("I absolutely loved it."))
+
+    assert factory.initialize_calls == 2  # warmup + predict sessions
+    assert factory.call_tool_calls == 1
+    assert factory.last_tool_name == "sentiment-classifier"
+
+    arguments = factory.last_arguments
+    assert arguments is not None
+    assert arguments["model"] == "sentiment-classifier"
+    assert arguments["metadata"]["uid"] == "example-1"
+    assert "Classify the review" in arguments["messages"][0]["content"]["text"]
+
+    assert response.output == "positive"
+    assert response.metadata["structured"] == {"score": 0.94}
+    assert response.metadata["tool"] == "sentiment-classifier"
+    assert response.metadata["server_info"]["name"] == "stub-server"
+
+
+def test_mcp_adapter_predict_triggers_warmup() -> None:
+    factory = FakeSessionFactory(
+        tool_name="demo-tool",
+        call_tool_result=_text_result("neutral"),
+    )
+    adapter = MCPModelAdapter(
+        endpoint="http://stub",
+        model_id="demo-tool",
+        session_factory=factory,
+    )
+
+    response = adapter.predict(_example("It's fine."))
+
+    assert response.output == "neutral"
+    # Warmup should have been performed automatically.
+    assert factory.list_tools_calls == 1
+    assert factory.call_tool_calls == 1
+
+
+def test_mcp_adapter_raises_on_server_error() -> None:
+    factory = FakeSessionFactory(
+        tool_name="demo-tool",
+        call_tool_result=_text_result("failure", structured={"reason": "invalid"}, is_error=True),
+    )
+    adapter = MCPModelAdapter(
+        endpoint="http://stub",
+        model_id="demo-tool",
+        session_factory=factory,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        adapter.predict(_example("bad input"))
+
+    message = str(excinfo.value)
+    assert "returned an error" in message
+    assert "invalid" in message
+
+
+def test_mcp_adapter_wraps_transport_errors() -> None:
+    error = McpError(mcp_types.ErrorData(code=mcp_types.INTERNAL_ERROR, message="transport boom"))
+    factory = FakeSessionFactory(
+        tool_name="demo-tool",
+        call_tool_result=_text_result("ignored"),
+        side_effect=error,
+    )
+    adapter = MCPModelAdapter(
+        endpoint="http://stub",
+        model_id="demo-tool",
+        session_factory=factory,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        adapter.predict(_example("hello"))
+
+    assert "MCP tool call failed" in str(excinfo.value)
+
+
+def test_mcp_adapter_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_TOKEN", "secret-token")
+    factory = FakeSessionFactory(
+        tool_name="demo-tool",
+        call_tool_result=_text_result("ok"),
+    )
+
+    adapter = MCPModelAdapter(
+        endpoint="http://stub",
+        model_id="demo-tool",
+        auth={"type": "bearer", "token_env": "MCP_TOKEN"},
+        session_factory=factory,
+    )
+
+    assert adapter._headers["Authorization"] == "Bearer secret-token"


### PR DESCRIPTION
## Summary
- add the MCP client library dependencies needed for the SSE transport
- implement an MCP-backed model adapter with warmup, request formatting, and error handling
- document the new adapter with an example config and deterministic tests against a fake MCP server

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf30da70008328a866b0cebf22ad59